### PR TITLE
Support Slack's interactive message webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.9
-  - master
+  - "1.10"
+  - "master"
 
 env:
   - DEP_VERSION="0.4.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/botopolis/slack/compare/v0.5.1...master)
+## [Unreleased](https://github.com/botopolis/slack/compare/v0.6.0...master)
+
+## [0.6.0](https://github.com/botopolis/slack/compare/v0.5.1...v0.6.0)
+
+### Added
+
+- Interactive slack messages (example [here](./action/example_test.go)) ([#1](https://github.com/botopolis/slack/pull/1))
 
 ## [0.5.1](https://github.com/botopolis/slack/compare/v0.5.0...v0.5.1)
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -7,8 +7,8 @@
     ".",
     "mock"
   ]
-  revision = "42e18825ca2ba54b7618854ac6a1f84100bcb9f2"
-  version = "v0.4.0"
+  revision = "86fafd6ef043ee02475bee9a12293cb047b9a847"
+  version = "v0.4.2"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -29,9 +29,24 @@
   version = "v1.6.1"
 
 [[projects]]
-  name = "github.com/nlopes/slack"
+  name = "github.com/gorilla/websocket"
   packages = ["."]
-  revision = "d86785d50d4be9c2e11cfbb0ed601f5dcb22899c"
+  revision = "66b9c49e59c6c48f0ffce28c2d8b8a5678502c6d"
+  version = "v1.4.0"
+
+[[projects]]
+  name = "github.com/nlopes/slack"
+  packages = [
+    ".",
+    "slackutilsx"
+  ]
+  revision = "752f784a75e8b640f048a8a453466cca64c83a47"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "c059e472caf75dbe73903f6521a20abac245b17f"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -45,15 +60,9 @@
   revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
   version = "v1.2.0"
 
-[[projects]]
-  branch = "master"
-  name = "golang.org/x/net"
-  packages = ["websocket"]
-  revision = "0ed95abb35c445290478a5348a7b38bb154135fd"
-
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "84eef14672425fa8ec1fc324e48d9cfc6f62df36aabf9203fe030861634041d8"
+  inputs-digest = "9606f60bf026b39694ccf26b2a929353e5ab425dd763437cec65b485e1b56333"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,10 +1,10 @@
 [[constraint]]
   name = "github.com/botopolis/bot"
-  version = "0.4.0"
+  version = "0.4.2"
 
 [[constraint]]
   name = "github.com/nlopes/slack"
-  revision = "d86785d50d4be9c2e11cfbb0ed601f5dcb22899c"
+  revision = "752f784a75e8b640f048a8a453466cca64c83a47"
 
 [[constraint]]
   name = "github.com/stretchr/testify"

--- a/action/README.md
+++ b/action/README.md
@@ -1,0 +1,5 @@
+# Slack Interactive Actions
+
+Work with Slack's interactive messages, documented [here](https://api.slack.com/interactive-messages).
+
+### [Usage](./example_test.go)

--- a/action/action.go
+++ b/action/action.go
@@ -1,0 +1,82 @@
+package action
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/botopolis/bot"
+	"github.com/nlopes/slack"
+)
+
+// Plugin conforms to the botopolis/bot.Plugin interface
+type Plugin struct {
+	*registry
+	// Path at which our webhook sits.
+	Path string
+	// Signing secret to verify message comes from slack.
+	SigningSecret string
+
+	logger bot.Logger
+}
+
+// New returns a new plugin taking arguments for path and token
+func New(path, signingSecret string) *Plugin {
+	return &Plugin{
+		registry:      &registry{},
+		Path:          path,
+		SigningSecret: signingSecret,
+	}
+}
+
+// Load installs the webhook
+func (p Plugin) Load(r *bot.Robot) {
+	p.logger = r.Logger
+	r.Router.HandleFunc(p.Path, p.webhook)
+}
+
+func (p Plugin) webhook(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+	p.logger.Debugf("slack/action: Received webhook to %s\n", p.Path)
+
+	if err := p.verify(r.Header, b); err != nil {
+		p.logger.Errorf("slack/action: Invalid webhook: %v\n", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	jsonBody := []byte(r.FormValue("payload"))
+	var cb slack.AttachmentActionCallback
+	if err := json.Unmarshal(jsonBody, &cb); err != nil {
+		p.logger.Errorf("slack/action: Invalid webhook: %v\n", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	go p.Run(cb)
+}
+
+func (p Plugin) verify(h http.Header, body []byte) error {
+	if h["X-Slack-Signature"] == nil || h["X-Slack-Request-Timestamp"] == nil {
+		return errors.New("Missing signing headers")
+	}
+
+	verifier, err := slack.NewSecretsVerifier(h, p.SigningSecret)
+	if err != nil {
+		return err
+	}
+
+	if _, err := verifier.Write(body); err != nil {
+		return err
+	}
+
+	return verifier.Ensure()
+}

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -1,0 +1,118 @@
+package action
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/botopolis/bot/mock"
+	"github.com/nlopes/slack"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	signingSecret = "e6b19c573432dcc6b075501d51b51bb8"
+
+	fooBody      = `payload=%7B%22callback_id%22%3A%22foo%22%7D`
+	fooSignature = "v0=d27668944a2857e8495256fc93c7aed9f1119617ec08902b56edf69862b16855"
+	barBody      = `payload=%7B%22callback_id%22%3A%22bar%22%7D`
+	barSignature = "v0=50179568ccb23da3e0dd88c0ac6da9e336ae9ed2895008d7d736807978e4e8bf"
+)
+
+func newHeader(signature string) http.Header {
+	h := http.Header{}
+	h.Set("Content-Type", "application/x-www-form-urlencoded")
+	h.Set("X-Slack-Signature", signature)
+	h.Set("X-Slack-Request-Timestamp", "1531431954")
+	return h
+}
+
+func readCloser(b []byte) io.ReadCloser {
+	return ioutil.NopCloser(bytes.NewReader(b))
+}
+
+var logger = mock.NewLogger()
+
+func init() {
+	logger.WriteFunc = func(l mock.Level, v ...interface{}) {
+		fmt.Println(v...)
+	}
+	logger.WritefFunc = func(l mock.Level, msg string, v ...interface{}) {
+		fmt.Printf(msg, v...)
+	}
+}
+
+func TestWebhook_response(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Body   []byte
+		Header http.Header
+		Out    int
+	}{
+		{
+			Name:   "With an empty header",
+			Body:   []byte(`payload=%7B%22token%22%3A%22foo%22%7D`),
+			Header: newHeader(""),
+			Out:    http.StatusBadRequest,
+		},
+		{
+			Name:   "With a non-JSON body",
+			Body:   []byte(`<xml></xml>`),
+			Header: newHeader("v0=242c2f40d58a5dbe4ae2d73ff61e07cf632a1d43a8e52a714e04e3fc4889cb7f"),
+			Out:    http.StatusBadRequest,
+		},
+		{
+			Name:   "With a bad header",
+			Body:   []byte(`payload=%7B%22token%22%3A%22foo%22%7D`),
+			Header: newHeader("bad header"),
+			Out:    http.StatusBadRequest,
+		},
+		{
+			Name:   "When everything's right",
+			Body:   []byte(`payload=%7B%22token%22%3A%22foo%22%7D`),
+			Header: newHeader("v0=9bff0c9ad4804e518f3bc03b7a8b3d3e360b78b368e601294574cc10878e7c13"),
+			Out:    http.StatusOK,
+		},
+	}
+
+	p := Plugin{SigningSecret: signingSecret, registry: &registry{}, logger: logger}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			p.webhook(recorder, &http.Request{
+				Body:   readCloser(c.Body),
+				Header: c.Header,
+				Method: "POST",
+			})
+			assert.Equal(t, c.Out, recorder.Code)
+		})
+	}
+}
+
+func TestWebhook_callback(t *testing.T) {
+	done := make(chan string, 3)
+	fooReq := http.Request{
+		Header: newHeader(fooSignature),
+		Body:   readCloser([]byte(fooBody)),
+		Method: "POST",
+	}
+	barReq := http.Request{
+		Header: newHeader(barSignature),
+		Body:   readCloser([]byte(barBody)),
+		Method: "POST",
+	}
+
+	p := Plugin{SigningSecret: signingSecret, registry: &registry{}, logger: logger}
+	p.Add("bar", func(slack.AttachmentActionCallback) { done <- "bar" })
+	p.Add("foo", func(slack.AttachmentActionCallback) { done <- "foo" })
+
+	p.webhook(httptest.NewRecorder(), &fooReq)
+	assert.Equal(t, "foo", <-done)
+
+	p.webhook(httptest.NewRecorder(), &barReq)
+	assert.Equal(t, "bar", <-done)
+}

--- a/action/example_test.go
+++ b/action/example_test.go
@@ -1,0 +1,63 @@
+package action_test
+
+import (
+	"fmt"
+
+	"github.com/botopolis/bot"
+	"github.com/botopolis/slack/action"
+	oslack "github.com/nlopes/slack"
+)
+
+type ExamplePlugin struct{}
+
+func (p ExamplePlugin) Load(r *bot.Robot) {
+	fmt.Println("Loaded")
+
+	var actions action.Plugin
+	if ok := r.Plugin(&actions); !ok {
+		r.Logger.Error("Example plugin requires slack/action.Plugin")
+		return
+	}
+
+	r.Hear(bot.Regexp("trigger"), func(r bot.Responder) error {
+		return r.Send(bot.Message{
+			Params: oslack.PostMessageParameters{
+				Attachments: []oslack.Attachment{{
+					Text:       "Trigger example",
+					CallbackID: "example",
+					Actions: []oslack.AttachmentAction{{
+						Name:  "check",
+						Type:  "button",
+						Text:  "Do it",
+						Value: "true",
+					}, {
+						Name:  "check",
+						Type:  "button",
+						Text:  "Nah",
+						Style: "danger",
+						Value: "false",
+					}},
+				}},
+			},
+		})
+	})
+
+	// handle example callback ID with a function
+	actions.Add("example", func(a oslack.AttachmentActionCallback) {
+		if len(a.Actions) < 0 {
+			return
+		}
+		if a.Actions[0].Value == "true" {
+			// do the thing
+		}
+	})
+}
+
+func Example() {
+	bot.New(
+		ExampleChat{},
+		action.New("/interaction", "signing secret!"),
+		ExamplePlugin{},
+	).Run()
+	// Output: Loaded
+}

--- a/action/mock_test.go
+++ b/action/mock_test.go
@@ -1,0 +1,15 @@
+package action_test
+
+import "github.com/botopolis/bot"
+
+type ExampleChat struct{}
+
+var exampleChan = make(chan bot.Message)
+
+func (ExampleChat) Username() string             { return "" }
+func (ExampleChat) Messages() <-chan bot.Message { return exampleChan }
+func (ExampleChat) Load(*bot.Robot)              { close(exampleChan) }
+func (ExampleChat) Send(bot.Message) error       { return nil }
+func (ExampleChat) Reply(bot.Message) error      { return nil }
+func (ExampleChat) Direct(bot.Message) error     { return nil }
+func (ExampleChat) Topic(bot.Message) error      { return nil }

--- a/action/registry.go
+++ b/action/registry.go
@@ -1,0 +1,37 @@
+package action
+
+import (
+	"sync"
+
+	"github.com/nlopes/slack"
+)
+
+type registry struct {
+	once      sync.Once
+	callbacks map[string]func(slack.AttachmentActionCallback)
+	mu        sync.Mutex
+}
+
+func (r *registry) init() {
+	r.once.Do(func() {
+		r.callbacks = make(map[string]func(slack.AttachmentActionCallback))
+	})
+}
+
+// Add registers a callback for the given callbackID
+func (r *registry) Add(callbackID string, fn func(slack.AttachmentActionCallback)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.init()
+	r.callbacks[callbackID] = fn
+}
+
+// Run runs the callback for the slack action
+func (r *registry) Run(cb slack.AttachmentActionCallback) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.init()
+	if fn, ok := r.callbacks[cb.CallbackID]; ok {
+		fn(cb)
+	}
+}

--- a/action/registry_test.go
+++ b/action/registry_test.go
@@ -1,0 +1,20 @@
+package action
+
+import (
+	"testing"
+
+	"github.com/nlopes/slack"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegistry(t *testing.T) {
+	counter := 0
+	callbackID := "foobar"
+	example := func(slack.AttachmentActionCallback) { counter++ }
+
+	r := registry{}
+	r.Add(callbackID, example)
+	r.Run(slack.AttachmentActionCallback{CallbackID: "foobar"})
+
+	assert.Equal(t, 1, counter)
+}


### PR DESCRIPTION
Slack will post to one endpoint per registered application with varying events being distinguished by "callback_id" rather than endpoint path.

Since the handling of these is generally going to be the same (as a whole) we can expose a unified way of dealing with it via the `"github.com/botopolis/slack/action"` plugin.