### PR TITLE
Fix a failed copy-paste

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -60,7 +60,7 @@ func emptyMessage(m bot.Message) bool {
 
 func (a *Adapter) send(m bot.Message) error {
 	if m.Params == nil {
-		a.proxy.RTM.NewOutgoingMessage(m.Text, m.Room)
+		a.proxy.RTM.SendMessage(a.proxy.RTM.NewOutgoingMessage(m.Text, m.Room))
 		return nil
 	}
 


### PR DESCRIPTION
Somehow managed to lose a function in the act of copy-pasting, resulting in messages not actually sending.

Somehow only copied the function that creates the message, leaving out the one that sends it.

There is no such thing as "just a small change".