### PR TITLE
Enforce a specific nlopes/slack version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -57,6 +57,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2238d723542c0e9cfb36a983d8aed3b0deab46d726cb05fafc5b23345d13a50b"
+  inputs-digest = "3dac3c2151027e27ed8440977447e6e8d1029977c5f1c08ced3e8cdf2f2c7402"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,6 +4,7 @@
 
 [[constraint]]
   name = "github.com/nlopes/slack"
+  revision = "d86785d50d4be9c2e11cfbb0ed601f5dcb22899c"
 
 [[constraint]]
   name = "github.com/stretchr/testify"


### PR DESCRIPTION
Currently v0.1.0 of nlopes/slack is _way_ behind. Enforce the version by revision to ensure our code works.