### PR TITLE
Improve test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+/c.out

--- a/example_test.go
+++ b/example_test.go
@@ -9,18 +9,7 @@ import (
 	slacker "github.com/nlopes/slack"
 )
 
-func Example_basic() {
-	robot := bot.New(
-		slack.New(os.Getenv("SLACK_TOKEN")),
-	)
-	robot.Hear(bot.Regexp("hi"), func(r bot.Responder) error {
-		r.Send(bot.Message{Text: "hi to you too, " + r.User})
-		return nil
-	})
-	robot.Run()
-}
-
-func Example_advanced() {
+func Example() {
 	robot := bot.New(
 		slack.New(os.Getenv("SLACK_TOKEN")),
 	)
@@ -79,7 +68,7 @@ func ExampleTopic() {
 	})
 }
 
-func Example_Store() {
+func ExampleStore() {
 	adapter := slack.New(os.Getenv("SLACK_TOKEN"))
 	// The store is only populated if:
 	// 1. You call adapter.Messages(), which connects it to RTM

--- a/mock_internal_test.go
+++ b/mock_internal_test.go
@@ -1,8 +1,11 @@
 package slack
 
 import (
+	"io/ioutil"
+
 	"github.com/botopolis/bot"
 	"github.com/nlopes/slack"
+	logging "github.com/op/go-logging"
 )
 
 type testProxy struct {
@@ -78,4 +81,12 @@ func (s *testStore) IMByUserID(id string) (slack.IM, bool) {
 		return s.IM, true
 	}
 	return s.IM, false
+}
+
+func nullLogger() *logging.Logger {
+	l := &logging.Logger{}
+	l.SetBackend(
+		logging.AddModuleLevel(logging.NewLogBackend(ioutil.Discard, "", 0)),
+	)
+	return l
 }

--- a/mock_internal_test.go
+++ b/mock_internal_test.go
@@ -1,8 +1,27 @@
 package slack
 
 import (
+	"github.com/botopolis/bot"
 	"github.com/nlopes/slack"
 )
+
+type testProxy struct {
+	C            chan bot.Message
+	SendFunc     func(bot.Message) error
+	SetTopicFunc func(room, topic string) error
+}
+
+func newTestProxy() *testProxy {
+	return &testProxy{
+		SendFunc:     func(bot.Message) error { return nil },
+		SetTopicFunc: func(string, string) error { return nil },
+	}
+}
+
+func (p *testProxy) Connect() chan bot.Message         { return p.C }
+func (p *testProxy) Disconnect()                       {}
+func (p *testProxy) Send(m bot.Message) error          { return p.SendFunc(m) }
+func (p *testProxy) SetTopic(room, topic string) error { return p.SetTopicFunc(room, topic) }
 
 type testStore struct {
 	LoadFunc   func(*slack.Info)

--- a/parse.go
+++ b/parse.go
@@ -91,7 +91,7 @@ func parseParams(a *Adapter, m *bot.Message) error {
 
 	pm.AsUser = true
 	if pm.User == "" {
-		pm.User = a.ID
+		pm.User = a.BotID
 	}
 	m.Params = pm
 

--- a/parse_internal_test.go
+++ b/parse_internal_test.go
@@ -125,7 +125,7 @@ func TestParseParams(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		parseParams(&Adapter{ID: id}, &c.In)
+		parseParams(&Adapter{BotID: id}, &c.In)
 		assert.Equal(t, c.Out, c.In)
 	}
 }
@@ -147,7 +147,7 @@ func TestParseChain(t *testing.T) {
 	store := newTestStore()
 	store.IM.ID = "D1234"
 	store.IM.User = "U4321"
-	a := Adapter{ID: "B1234", Store: store}
+	a := Adapter{BotID: "B1234", Store: store}
 
 	a.parse(&in, parseDM, parseParams)
 	assert.Equal(t, out, in)

--- a/slack_test.go
+++ b/slack_test.go
@@ -1,0 +1,240 @@
+package slack
+
+import (
+	"testing"
+
+	"github.com/botopolis/bot"
+	"github.com/nlopes/slack"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSend_blank(t *testing.T) {
+	proxy := newTestProxy()
+	proxy.SendFunc = func(bot.Message) error {
+		t.Errorf("Should not call Send")
+		return nil
+	}
+	adapter := Adapter{proxy: proxy}
+	assert.Nil(t, adapter.Send(bot.Message{}))
+}
+
+func TestSend_parse(t *testing.T) {
+	user := "U1234"
+	cases := []struct {
+		In  bot.Message
+		Out bot.Message
+		Err bool
+	}{
+		{
+			In:  bot.Message{Room: "general", Text: "foo"},
+			Out: bot.Message{Room: "C1234", Text: "foo"},
+		},
+		{
+			In: bot.Message{Room: "general", Params: slack.PostMessageParameters{}},
+			Out: bot.Message{Room: "C1234", Params: slack.PostMessageParameters{
+				AsUser: true,
+				User:   user,
+			}},
+		},
+		{
+			In:  bot.Message{Room: "random", Text: "foo"},
+			Err: true,
+		},
+	}
+	store := newTestStore()
+	store.Channel.ID = "C1234"
+	store.Channel.Name = "general"
+
+	for _, c := range cases {
+		proxy, run := setUpProxySend(t, c.Out)
+		adapter := Adapter{Store: store, proxy: proxy, BotID: user}
+		err := adapter.Send(c.In)
+		if c.Err {
+			assert.NotNil(t, err)
+			assert.False(t, *run)
+		} else {
+			assert.Nil(t, err)
+			assert.True(t, *run)
+		}
+	}
+}
+
+func TestDirect_blank(t *testing.T) {
+	proxy := newTestProxy()
+	proxy.SendFunc = func(bot.Message) error {
+		t.Errorf("Should not call Send")
+		return nil
+	}
+	adapter := Adapter{proxy: proxy}
+	assert.Nil(t, adapter.Direct(bot.Message{}))
+}
+
+func TestDirect(t *testing.T) {
+	user := "U1234"
+	cases := []struct {
+		In  bot.Message
+		Out bot.Message
+		Err bool
+	}{
+		{
+			In:  bot.Message{Room: "D4321", Text: "foo"},
+			Out: bot.Message{Room: "D4321", Text: "foo"},
+		},
+		{
+			In:  bot.Message{User: user, Text: "foo"},
+			Out: bot.Message{User: user, Room: "D1234", Text: "foo"},
+		},
+		{
+			In:  bot.Message{User: "Jean", Room: "general", Text: "foo"},
+			Out: bot.Message{User: user, Room: "D1234", Text: "foo"},
+		},
+		{
+			In:  bot.Message{User: "Jane", Room: "general", Text: "foo"},
+			Err: true,
+		},
+		{
+			In: bot.Message{User: "Jean", Room: "general", Params: slack.PostMessageParameters{}},
+			Out: bot.Message{User: user, Room: "D1234", Params: slack.PostMessageParameters{
+				AsUser: true,
+				User:   user,
+			}},
+		},
+	}
+	store := newTestStore()
+	store.Channel.ID = "C1234"
+	store.Channel.Name = "general"
+	store.User.ID = user
+	store.User.Name = "Jean"
+	store.IM.ID = "D1234"
+	store.IM.User = user
+
+	for _, c := range cases {
+		proxy, run := setUpProxySend(t, c.Out)
+		adapter := Adapter{Store: store, proxy: proxy, BotID: user}
+		err := adapter.Direct(c.In)
+		if c.Err {
+			assert.NotNil(t, err)
+			assert.False(t, *run)
+		} else {
+			assert.Nil(t, err)
+			assert.True(t, *run)
+		}
+	}
+}
+
+func TestReply_blank(t *testing.T) {
+	proxy := newTestProxy()
+	proxy.SendFunc = func(bot.Message) error {
+		t.Errorf("Should not call Send")
+		return nil
+	}
+	adapter := Adapter{proxy: proxy}
+	assert.Nil(t, adapter.Reply(bot.Message{}))
+}
+
+func TestReply(t *testing.T) {
+	user := "U1234"
+	envelope := slack.Message{}
+	envelope.User = user
+
+	cases := []struct {
+		In  bot.Message
+		Out bot.Message
+		Err bool
+	}{
+		{
+			In:  bot.Message{Room: "D4321", Text: "foo", Envelope: envelope},
+			Out: bot.Message{User: user, Room: "D4321", Text: "foo", Envelope: envelope},
+		},
+		{
+			In:  bot.Message{Room: "general", Text: "foo", Envelope: envelope},
+			Out: bot.Message{User: user, Room: "C1234", Text: "<@U1234> foo", Envelope: envelope},
+		},
+		{
+			In:  bot.Message{User: "Jane", Room: "general", Text: "foo"},
+			Err: true,
+		},
+		{
+			In:  bot.Message{User: user, Text: "foo"},
+			Err: true,
+		},
+	}
+	store := newTestStore()
+	store.Channel.ID = "C1234"
+	store.Channel.Name = "general"
+	store.User.ID = user
+	store.User.Name = "Jean"
+
+	for _, c := range cases {
+		proxy, run := setUpProxySend(t, c.Out)
+		adapter := Adapter{Store: store, proxy: proxy, BotID: user}
+		err := adapter.Reply(c.In)
+		if c.Err {
+			assert.NotNil(t, err)
+			assert.False(t, *run)
+		} else {
+			assert.Nil(t, err)
+			assert.True(t, *run)
+		}
+	}
+}
+
+func TestTopic(t *testing.T) {
+	cases := []struct {
+		In  bot.Message
+		Out bot.Message
+		Err bool
+	}{
+		{
+			In:  bot.Message{Room: "general", Topic: "foo"},
+			Out: bot.Message{Room: "C1234", Topic: "foo"},
+		},
+		{
+			In:  bot.Message{Room: "general", Topic: ""},
+			Out: bot.Message{Room: "C1234", Topic: ""},
+		},
+		{
+			In:  bot.Message{Room: "random", Topic: ""},
+			Err: true,
+		},
+		{
+			In:  bot.Message{Topic: ""},
+			Err: true,
+		},
+	}
+	store := newTestStore()
+	store.Channel.ID = "C1234"
+	store.Channel.Name = "general"
+
+	for _, c := range cases {
+		var run bool
+		proxy := newTestProxy()
+		proxy.SetTopicFunc = func(room, topic string) error {
+			assert.Equal(t, c.Out.Room, room)
+			assert.Equal(t, c.Out.Topic, topic)
+			run = true
+			return nil
+		}
+		adapter := Adapter{Store: store, proxy: proxy}
+		err := adapter.Topic(c.In)
+		if c.Err {
+			assert.NotNil(t, err)
+			assert.False(t, run)
+		} else {
+			assert.Nil(t, err)
+			assert.True(t, run)
+		}
+	}
+}
+
+func setUpProxySend(t *testing.T, out bot.Message) (*testProxy, *bool) {
+	var run bool
+	proxy := newTestProxy()
+	proxy.SendFunc = func(m bot.Message) error {
+		assert.Equal(t, out, m)
+		run = true
+		return nil
+	}
+
+	return proxy, &run
+}

--- a/store_test.go
+++ b/store_test.go
@@ -1,0 +1,98 @@
+package slack
+
+import (
+	"testing"
+
+	"github.com/nlopes/slack"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStore_users(t *testing.T) {
+	store := newMemoryStore(&slack.Client{})
+	info := slackUserInfo()
+	store.Load(info)
+
+	var (
+		user slack.User
+		ok   bool
+	)
+
+	user, ok = store.UserByID("U1234")
+	assert.Equal(t, info.Users[0], user)
+	assert.True(t, ok)
+
+	_, ok = store.UserByID("U4321")
+	assert.False(t, ok)
+
+	user, ok = store.UserByName("Jean")
+	assert.Equal(t, info.Users[0], user)
+	assert.True(t, ok)
+
+	_, ok = store.UserByName("Joan")
+	assert.False(t, ok)
+}
+
+func TestStore_channels(t *testing.T) {
+	store := newMemoryStore(&slack.Client{})
+	info := slackUserInfo()
+	store.Load(info)
+
+	var (
+		channel slack.Channel
+		ok      bool
+	)
+
+	channel, ok = store.ChannelByID("C1234")
+	assert.Equal(t, info.Channels[0], channel)
+	assert.True(t, ok)
+
+	_, ok = store.ChannelByID("C4321")
+	assert.False(t, ok)
+
+	channel, ok = store.ChannelByName("general")
+	assert.Equal(t, info.Channels[0], channel)
+	assert.True(t, ok)
+
+	_, ok = store.ChannelByName("random")
+	assert.False(t, ok)
+}
+
+func TestStore_ims(t *testing.T) {
+	store := newMemoryStore(&slack.Client{})
+	info := slackUserInfo()
+	store.Load(info)
+
+	var (
+		im slack.IM
+		ok bool
+	)
+
+	im, ok = store.IMByID("D1234")
+	assert.Equal(t, info.IMs[0], im)
+	assert.True(t, ok)
+
+	_, ok = store.IMByID("D4321")
+	assert.False(t, ok)
+
+	im, ok = store.IMByUserID("U1234")
+	assert.Equal(t, info.IMs[0], im)
+	assert.True(t, ok)
+
+	_, ok = store.IMByUserID("U4321")
+	assert.False(t, ok)
+}
+
+func slackUserInfo() *slack.Info {
+	user := slack.User{ID: "U1234", Name: "Jean"}
+	channel := slack.Channel{}
+	channel.ID = "C1234"
+	channel.Name = "general"
+	im := slack.IM{}
+	im.ID = "D1234"
+	im.User = "U1234"
+	return &slack.Info{
+		Users:    []slack.User{user},
+		Channels: []slack.Channel{channel},
+		IMs:      []slack.IM{im},
+	}
+}


### PR DESCRIPTION
This PR's purpose is to improve the test coverage of this package.  Notably, we're refactoring internals in order to make testing interactions with Slack's API easier.

My aim here is to only have untested code for one of two reasons:

1. The code is a wrapper around an external codebase (much of `proxy`)
2. Testing the code doesn't do anything that the type system isn't doing (for example, checking that `Username()` returns a string)


### Todo

- [x] Leverage proxy to allow for testing of `Send`, `Direct`, `Reply` and `Topic`
- [x] Add tests for `Store`
- [x] Add test for `proxy.onConnect`
- [x] Improve coverage of `proxy.Forward`


### Proxy refactor

Proxy can be an interface. This also means that when we're testing, we can test the adapter's `Send`, `Direct` and `Reply` methods by using `proxy.Send` and `Topic` by using `proxy.SetTopic`.

Other refactors:

1. Had a useless sync.Mutex on the adapter before, removed in favor of making the store actually threadsafe
2. Removed duplicate fields from `Adapter`, standardized on `BotID`
3. Move onConnect out of top-level, let Proxy handle that behavior since it embeds the adapter

#### Note

Should potentially be able to remove parse unit tests down the road as they are consolidated into higher level tests.

_This refactor is a pretty clear symptom of not having gone with TDD for the initial implementation here._