### PR TITLE
format,proxy: Use RealName for replies

### DIFF
--- a/format.go
+++ b/format.go
@@ -42,6 +42,9 @@ func (f formatter) formatLinks(in string) string {
 				return "@" + label
 			}
 			if user, ok := f.store.UserByID(link); ok {
+				if user.RealName != "" {
+					return "@" + user.RealName
+				}
 				return "@" + user.Name
 			}
 		case "#":

--- a/format_internal_test.go
+++ b/format_internal_test.go
@@ -112,6 +112,9 @@ func TestFormatter(t *testing.T) {
 	for _, c := range formatTestCases {
 		assert.Equal(c.Out, f.Format(&slack.MessageEvent{Msg: slack.Msg{Text: c.In}}), c.Should)
 	}
+
+	store.User = slack.User{ID: "U1234", RealName: "bobby", Name: "bob"}
+	assert.Equal("foo @bobby bar", f.Format(&slack.MessageEvent{Msg: slack.Msg{Text: "foo <@U1234> bar"}}), "use real name")
 }
 
 func TestFormatter_fallback(t *testing.T) {

--- a/proxy.go
+++ b/proxy.go
@@ -36,11 +36,6 @@ func (p *proxy) onConnect(ev *slack.ConnectedEvent) {
 		return
 	}
 
-	if user.Profile.DisplayName != "" {
-		p.Name = user.Profile.DisplayName
-		return
-	}
-
 	if user.Profile.RealName != "" {
 		p.Name = user.Profile.RealName
 	}


### PR DESCRIPTION
Fixes bug where replies don't work when RealName and Name are different, introduced in #16 